### PR TITLE
Configure dock to minimize application on click

### DIFF
--- a/scripts/ubuntu-25.04-setup.sh
+++ b/scripts/ubuntu-25.04-setup.sh
@@ -231,5 +231,9 @@ if [ "$SETUP_GUI_TOOLS" = true ]; then
     setup_gui_tools
 fi
 
+# Configure dock behavior to minimize windows when clicking on open app icons
+echo "Configuring dock to minimize windows when clicking on open applications..."
+gsettings set org.gnome.shell.extensions.dash-to-dock click-action 'minimize'
+
 echo
 echo "Setup completed successfully!"


### PR DESCRIPTION
Add gsettings command to Ubuntu setup script to minimize windows when clicking dock icons.

---

[Open in Web](https://www.cursor.com/agents?id=bc-0f2e5411-6e48-44ad-ad14-7a1c1db2a7db) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0f2e5411-6e48-44ad-ad14-7a1c1db2a7db)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)